### PR TITLE
Release 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-durations-export"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "tracing-durations-export"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "Record and visualize parallelism of tracing spans"
 license = "MIT OR Apache-2.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.5
+
+- Support dark mode in SVG export
+- Use PEP 723 inline script metadata and a lockfile for `plot.py`
+
 ## 0.3.4
 
 - Use unique IDs for exported spans


### PR DESCRIPTION
- Support dark mode in SVG export
- Use PEP 723 inline script metadata and a lockfile for plot.py